### PR TITLE
Address #43 Rare bug in PDF417 barcode generator

### DIFF
--- a/src/java/org/krysalis/barcode4j/impl/pdf417/PDF417HighLevelEncoder.java
+++ b/src/java/org/krysalis/barcode4j/impl/pdf417/PDF417HighLevelEncoder.java
@@ -301,7 +301,7 @@ public class PDF417HighLevelEncoder implements PDF417Constants {
         StringBuffer tmp = new StringBuffer(count / 3 + 1);
         final BigInteger num900 = BigInteger.valueOf(900);
         final BigInteger num0 = BigInteger.valueOf(0);
-        while (idx < count - 1) {
+        while (idx < count) {
             tmp.setLength(0);
             int len = Math.min(44, count - idx);
             String part = "1" + msg.substring(startpos + idx, startpos + idx + len);


### PR DESCRIPTION
This implements suggested fix for bug reported to SourceForge project.

If a value to be enceded as PDF417 contains a run of 45 digits (0-9) and invalid barcode is generated. The issue is rare in that it happens only when there are exactly 45 consequtive digits. For example, error happens with 45 digits but not with 44 or 46.

Original bug report:
https://sourceforge.net/p/barcode4j/bugs/43/